### PR TITLE
Docker 1.6 and 1.7 change the output format

### DIFF
--- a/docker-gc
+++ b/docker-gc
@@ -63,7 +63,7 @@ function elapsed_time() {
     # Docker 1.5.0 datetime format is 2015-07-03T02:39:00.390284991
     # Docker 1.7.0 datetime format is 2015-07-03 02:39:00.390284991 +0000 UTC
     utcnow=$(date -u "+%s")
-    without_ms="${1:0:19}"
+    without_ms="${1:1:19}"
     replace_t="${without_ms/T/ }"
     epoch=$(date_parse "${replace_t}")
     echo $(($utcnow - $epoch))


### PR DESCRIPTION
This seems like a docker bug to be honest, there is no reason a quote should come out of that template. But this fixes the issue for 1.6.x and 1.7.x.

I don't expect this PR to be accepted because it would surely break it for Docker 1.5.x. 

Relates to #29
